### PR TITLE
replace \n in transcripts with space

### DIFF
--- a/ted_talks/scraper.py
+++ b/ted_talks/scraper.py
@@ -699,7 +699,7 @@ class TEDScraper:
         :param str s:
         :rtype: str
         """
-        return s.get_text().replace("\n", "")
+        return s.get_text().replace("\n", " ")
 
     def _format_filename(self, s):
         """


### PR DESCRIPTION
Hi, I would like to first thank you for writing this excellent project. Here is a minor thing I thing you can change. I found in the original text, sentences are separated by \n rather than punctuations. Deleting them will result in very long sentences.